### PR TITLE
Pass version to install command as to not use find

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# asdf-kafka
+
+[![Travis](https://img.shields.io/travis/skotchpine/asdf-kafka/master.svg?style=flat-square)](https://travis-ci.org/skotchpine/asdf-kafka)
+
+## Install
+
+```
+asdf plugin-add kafka https://github.com/skotchpine/asdf-kafka.git
+```
+
+## Usage
+
+Check [asdf readme](https://github.com/asdf-vm/asdf) for instructions on how to install & manage versions of `kafka`.
+
+## Starting Kafka
+
+<!-- stolen from: https://github.com/JoshAshby/asdf-kafka -->
+```bash
+$ zookeeper-server-start.sh "$(asdf where kafka)/config/zookeeper.properties"
+$ kafka-server-start.sh "$(asdf where kafka)/config/server.properties"
+```

--- a/bin/install
+++ b/bin/install
@@ -10,10 +10,10 @@ install_kafka() {
 
 	read -r scala_version release <<< $(echo $version | sed -e 's|-| |')
 
-	download_kafka $scala_version $release $dir
+	download_kafka "$scala_version" "$release" "$dir"
 	[[ -z "$ASDF_KAFKA_ERROR" ]] || return
 
-	unpack_kafka $dir $version
+	unpack_kafka "$dir" "$version"
 	[[ -z "$ASDF_KAFKA_ERROR" ]] || return
 }
 
@@ -24,8 +24,8 @@ download_kafka() {
 	local dir=$3
 
 	local base=http://archive.apache.org/dist/kafka
-	local variant=kafka_$scala_version'-'$release.tgz
-	local url=$base/$release/$variant
+	local variant="kafka_$scala_version-$release.tgz"
+	local url="$base/$release/$variant"
 
 	echo "---- ASDF KAFKA MESSAGE ----"
 	echo "downloading: $url"
@@ -34,7 +34,7 @@ download_kafka() {
 		--silent \
 		--retry 3 \
 		--retry-delay 3 \
-		-o $dir/$variant $url
+		-o "$dir/$variant" "$url"
 
 	[[ $? != 0 ]] && ASDF_KAFKA_ERROR="downloading kafka dist"
 }
@@ -48,11 +48,12 @@ download_kafka() {
 unpack_kafka() {
 	local dir=$1
 	local version=$2
-	local archive=$dir/kafka_$version.tgz
 
-	tar -xzf $archive -C $dir --strip-components=1
+	local archive="$dir/kafka_$version.tgz"
+
+	tar -xzf "$archive" -C "$dir" --strip-components=1
 	[[ $? == 0 ]] || ASDF_KAFKA_ERROR="expanding kafka dist"
-	rm $archive
+	rm "$archive"
 }
 
 #

--- a/bin/install
+++ b/bin/install
@@ -13,7 +13,7 @@ install_kafka() {
 	download_kafka $scala_version $release $dir
 	[[ -z "$ASDF_KAFKA_ERROR" ]] || return
 
-	unpack_kafka $dir
+	unpack_kafka $dir $version
 	[[ -z "$ASDF_KAFKA_ERROR" ]] || return
 }
 
@@ -47,20 +47,12 @@ download_kafka() {
 # TODO: Should be sanitized with error reporting.
 unpack_kafka() {
 	local dir=$1
+	local version=$2
+	local archive=$dir/kafka_$version.tgz
 
-	local origin=$(pwd)
-	cd $dir; {
-		local archive=$(find -name kafka*tgz -printf '%f')
-
-		tar -xzf $archive
-		[[ $? == 0 ]] || ASDF_KAFKA_ERROR="expanding kafka dist"
-
-		rm $archive
-
-		local dist=$(find -name kafka* -printf '%f')
-		mv $dist/* .
-		rm -r $dist
-	}; cd $origin
+	tar -xzf $archive -C $dir --strip-components=1
+	[[ $? == 0 ]] || ASDF_KAFKA_ERROR="expanding kafka dist"
+	rm $archive
 }
 
 #
@@ -74,5 +66,8 @@ if ! [[ -z "$ASDF_KAFKA_ERROR" ]]; then
 	echo "---- ASDF KAFKA ERROR ----"
 	echo "asdf kafka failed while $ASDF_KAFKA_ERROR"
 	echo "----"
+else
+	echo "---- ASDF KAFKA INSTALL SUCCESS --"
 fi
+
 unset ASDF_KAFKA_ERROR


### PR DESCRIPTION
It was not installing on MacOS.

Since now we have the full name of the version we don't need to use find to find (hehe) the downloaded archive, we just use the version prepend with `kafka_`, e.g. `kafka_$version`.

This prevent a whole class of bugs, especially when we are talking about differences between the commands in GNU/Linux system vs BSD based ones (MacOS).

One of those bugs is that BSD find does not support the `-name` flag, which was erroring out. 
Because of that, the `$dist` variable was not rightfully populated, which could be troublesome since in the next line we were doing an `mv $dist/* .` and an `rf -r $dist`, both of which are destructive actions.

### Additional changes
- Added double quotes to every variable in the `install` script
- Added a README with some simple usage instruction (closes #1 )